### PR TITLE
Add vi bindings, and the freestyle usage mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 _Meet **Scoot**, your friendly cursor teleportation and actuation tool._
 
-<img src="https://github.com/mjrusso/scoot/actions/workflows/main_test.yml/badge.svg" alt="build status"></a>
+Scoot helps you efficiently move your mouse cursor, using keyboard shortcuts!
 
-<a href="https://twitter.com/mjrusso" title="@mjrusso on Twitter"><img src="https://img.shields.io/badge/twitter-@mjrusso-blue.svg" alt="@mjrusso on Twitter"></a>
+For updates, [follow @mjrusso on Twitter](https://twitter.com/mjrusso).
+
+<img src="https://github.com/mjrusso/scoot/actions/workflows/main_test.yml/badge.svg" alt="build status"></a>
 
 <p align="center">
   <img src="./Assets/card.png" alt="Scoot, MacOS Cursor Actuator" />
@@ -14,9 +16,9 @@ _Meet **Scoot**, your friendly cursor teleportation and actuation tool._
 
 <img align="right" width="128" alt="Scoot App Icon" src="./Scoot/Assets.xcassets/AppIcon.appiconset/512.png" />
 
-Scoot is a tiny utility app that provides fast, keyboard-driven control over the mouse pointer. Scoot lets you move your mouse—and click and drag, too—all from the comfort of your keyboard!
+Scoot is a tiny utility app that provides fast, keyboard-driven control over the mouse pointer. Scoot lets you move your mouse—and click and drag, too—all from the comfort of your keyboard.
 
-Scoot supports two navigation modes: **element-based**, and **grid-based**.
+Scoot supports two primary navigation modes: **element-based**, and **grid-based**.
 
 * **Element-based navigation:** MacOS accessibility APIs are used to find user interface elements, such as buttons and links, on the user's screen. (In this mode, Scoot will look for elements in the focused window of the frontmost app.) Here, for example, Scoot has identified the only link on the page _("More information...")_, and assigned it the key sequence "aa":
 
@@ -32,6 +34,14 @@ Scoot supports two navigation modes: **element-based**, and **grid-based**.
 
 Each location is identified by a unique character sequence, making each element (or cell) uniquely addressable with the keyboard — simply type the associated key sequence to teleport your mouse cursor to that location.
 
+Scoot also supports moving the mouse cursor using text editing keyboard shortcuts that you're likely already familiar with (specifically, those for moving the insertion point). Scoot supports standard MacOS text editing shortcuts, as well as Emacs and vi keybindings. For a full breakdown, see the [usage documentation](#usage).
+
+There's also a supplementary usage mode:
+
+* **Freestyle:** a freeform usage mode that offers no special navigation assistance. It's like using the grid-based navigation mode, but _without_ bringing up the grid.
+
+Freestyle mode is particularly handy for those cases where you want to quickly nudge the cursor using the (re-purposed) text editing keyboard shortcuts, and would prefer to not have the grid or element-based views on screen.
+
 ## About
 
 * Scoot is experimental. Is it possible to craft a keyboard-driven mouse movement utility that's _actually_ efficient? Something that you'll actually _want_ to use? This is going to take some trial and error.
@@ -40,23 +50,25 @@ Each location is identified by a unique character sequence, making each element 
 
 * Scoot runs on MacOS 11 (Big Sur), and 12 (Monterey).
 
-* Scoot is an AppKit app, written in Swift. (There's still [some][carbon-events] [Carbon][carbon-accessibility] in here, too!)
+* Scoot is an AppKit app, written in Swift. (There's still some Carbon in here, too! [Yes][carbon-events], [really][carbon-accessibility].)
 
-* Scoot complements mouse-related accessibility tools that ship as part of MacOS, such as [Mouse Keys][mouse-keys] and other [accessibility shortcuts][mac-accessibility-shortcuts], in addition to mouse emulation provided via keyboard firmware like [QMK][qmk-mouse-keys].
+* Scoot complements mouse-related accessibility tools that ship as part of MacOS, such as [Mouse Keys][mouse-keys] and other [accessibility shortcuts][mac-accessibility-shortcuts], in addition to mouse emulation provided via keyboard firmware ([QMK][qmk-mouse-keys], for example).
 
 ## Usage
 
-To activate Scoot in the **element-based navigation mode**, use the ⇧⌘J global keyboard shortcut. Alternatively, to activate Scoot in the **grid-based navigation mode**, use the ⇧⌘K global keyboard shortcut.
+To activate Scoot in the **element-based navigation mode**, use the ⇧⌘J global keyboard shortcut. Alternatively, to activate Scoot in the **grid-based navigation mode**, use the ⇧⌘K global keyboard shortcut. And for **freestyle mode**, use the ⇧⌘L global keyboard shortcut.
 
-(As long as Scoot is running, either hotkey will bring the app to the foreground, and activate the requested navigation mode.)
+(As long as Scoot is running, any of these hotkeys will bring the app to the foreground, and activate the requested mode.)
 
 When Scoot is in the foreground:
 
 * You can jump directly to a cell (a UI element, or a location in the grid, depending on the active navigation mode). Each cell is marked with a label (e.g. “aaa”, “aas”, “aad”); type the characters, one letter at a time, and, as soon as a complete sequence is entered, the mouse cursor will move directly to the center of the corresponding cell. (This approach, including the use of a char-based decision tree, is heavily inspired by [avy][avy].)
   * If you make a mistake while entering a label, hit the escape key (⎋) to cancel and start over. (Alternatively, you can type ⌘. or C-G.)
+  * This feature is not available in freestyle mode, which does not present any special UI, or otherwise offer any navigation assistance via a char-based decision tree.
 
-* You can _also_ move the cursor via the standard Mac keyboard shortcuts for [moving the insertion point][mac-keyboard-shortcuts-text]. (This means that keyboard shortcuts intended for navigating around in a document have been re-purposed to control movement on a 2-dimensional grid. Some liberties have been taken with this mapping; hopefully you find these keybindings intuitive.)
+* You can _also_ move the cursor via the standard Mac keyboard shortcuts for [moving the insertion point][mac-keyboard-shortcuts-text]. (This means that keyboard shortcuts intended for navigating around in a document have been re-purposed to control movement on a 2-dimensional grid. Some liberties have been taken with this mapping; hopefully you find these keybindings intuitive.) This feature works in _all_ modes (element-based, grid-based, and freestyle).
     * The equivalent standard Emacs keybindings should also work out-of-the-box, if you have them configured system-wide (for example, via [Karabiner-Elements][karabiner-elements] [[complex modification][karabiner-elements-emacs-mod]], or by augmenting the [system defaults][emacs-keyboard-shortcuts-osx] [[DefaultKeyBinding.dict][defaultkeybinding.dict], [Cocoa Text System][cocoa-text-system], [Text System Defaults and Key Bindings][apple-dev-text-system]]).
+    * The equivalent vi bindings are also (optionally) available; see [keybindings](#keybindings) for details.
 
 * You can click with the left mouse button (at the current cursor location) by hitting the Return (↵) key.
 
@@ -67,39 +79,41 @@ When Scoot is in the foreground:
 
 * You can scroll, by pressing the Shift key in conjunction with the arrow key (↑, ↓, ←, →) pointing in the desired scroll direction.
 
-After clicking, the grid will automatically hide. You can also hide the grid at any time by pressing ⌘H.
+After clicking, any overlaid UI elements (such as the element view, or the grid) will automatically hide. You can also hide these UI elements (and send Scoot to the background) at any time by pressing ⌘H.
 
 ### Keybindings
 
 _Not sure what these symbols mean? See the [symbol reference][what-are-those-mac-symbols], and [Emacs key notation][emacs-key-notation]._
 
+Note that vi keybindings are not enabled by default, and must be explicitly toggled on (documentation: [how to turn on vi keybindings](#activating-vi-keybindings)). Emacs keybindings (and most system keybindings) are disabled when vi keybindings are active.
 
-| Shortcut  | Emacs | Description                                                                                                       |
-|-----------|-------|-------------------------------------------------------------------------------------------------------------------|
-| ⇧⌘J       |       | Use element-based navigation (bring Scoot to foreground)                                                          |
-| ⇧⌘K       |       | Use grid-based navigation (bring Scoot to foreground)                                                             |
-| ⌘H        |       | Hide UI (bring Scoot to background)                                                                               |
-| ⎋ (or ⌘.) | C-g   | Cancel: if currently typing a label, clears all currently-typed characters; otherwise, brings Scoot to background |
+| Shortcut  | Alternate | Description                                                                                                       |
+|-----------|-----------|-------------------------------------------------------------------------------------------------------------------|
+| ⇧⌘J       |           | Use element-based navigation (bring Scoot to foreground)                                                          |
+| ⇧⌘K       |           | Use grid-based navigation (bring Scoot to foreground)                                                             |
+| ⇧⌘L       |           | Use freestyle mode (bring Scoot to foreground)                                                                    |
+| ⌘H        |           | Hide UI (bring Scoot to background)                                                                               |
+| ⎋ (or ⌘.) | C-g       | Cancel: if currently typing a label, clears all currently-typed characters; otherwise, brings Scoot to background |
 
 _Note:_ ⎋ signifies the Escape key.
 
 #### Cursor Movement
 
-| System | Emacs | Description                                                 |
-|--------|-------|-------------------------------------------------------------|
-| ↑      | C-p   | Move cursor up (partial step)                               |
-| ↓      | C-n   | Move cursor down (partial step)                             |
-| ←      | C-b   | Move cursor left (partial step)                             |
-| →      | C-f   | Move cursor right (partial step)                            |
-| ⌥↑     | M-a   | Move cursor up (full step)                                  |
-| ⌥↓     | M-e   | Move cursor down (full step)                                |
-| ⌥←     | M-b   | Move cursor left (full step)                                |
-| ⌥→     | M-f   | Move cursor right (full step)                               |
-| ⌘↑     | M-<   | Move cursor to top edge of screen                           |
-| ⌘↓     | M->   | Move cursor to bottom edge of screen                        |
-| ⌘←     | C-a   | Move cursor to left edge of screen                          |
-| ⌘→     | C-e   | Move cursor to right edge of screen                         |
-| ⌃L     | C-l   | Move cursor to center, and (on repeat) cycle around corners |
+| System | Emacs | vi  | Description                                                 |
+|--------|-------|-----|-------------------------------------------------------------|
+| ↑      | C-p   | j   | Move cursor up (partial step)                               |
+| ↓      | C-n   | k   | Move cursor down (partial step)                             |
+| ←      | C-b   | h   | Move cursor left (partial step)                             |
+| →      | C-f   | l   | Move cursor right (partial step)                            |
+| ⌥↑     | M-a   | C-j | Move cursor up (full step)                                  |
+| ⌥↓     | M-e   | C-k | Move cursor down (full step)                                |
+| ⌥←     | M-b   | C-h | Move cursor left (full step)                                |
+| ⌥→     | M-f   | C-l | Move cursor right (full step)                               |
+| ⌘↑     | M-<   | ⇧-j | Move cursor to top edge of screen                           |
+| ⌘↓     | M->   | ⇧-k | Move cursor to bottom edge of screen                        |
+| ⌘←     | C-a   | ⇧-h | Move cursor to left edge of screen                          |
+| ⌘→     | C-e   | ⇧-l | Move cursor to right edge of screen                         |
+| ⌃L     | C-l   | ⇧-m | Move cursor to center, and (on repeat) cycle around corners |
 
 #### Clicking
 
@@ -107,18 +121,18 @@ _Note:_ ⎋ signifies the Escape key.
 |----------|-----------------------------------------------------------------------------|
 | ↵        | Click left mouse button (at current cursor location)                        |
 | ⌘↵       | Press and hold left mouse button (once activated, type ⌘↵ again to release) |
-| ⇧↵       | Double-click left mouse button (at current cursor location) |
+| ⇧↵       | Double-click left mouse button (at current cursor location)                 |
 
 _Note:_ ↵ signifies the Return (a.k.a Enter) key. (Technically, Return and Enter are [two different keys][return-and-enter-are-two-different-keys].)
 
 #### Scrolling
 
-| System | Alt | Description                              |
-|--------|-----|------------------------------------------|
-| ⇧↑     | ⇧-p | Scroll up (at current cursor location) |
-| ⇧↓     | ⇧-n | Scroll down (at current cursor location) |
-| ⇧←     | ⇧-b | Scroll left (at current cursor location) |
-| ⇧→     | ⇧-f | Scroll right (at current cursor location) |
+| System | Emacs | vi  | Description                               |
+|--------|-------|-----|-------------------------------------------|
+| ⇧↑     | ⇧-p   | C-b | Scroll up (at current cursor location)    |
+| ⇧↓     | ⇧-n   | C-f | Scroll down (at current cursor location)  |
+| ⇧←     | ⇧-b   | C-i | Scroll left (at current cursor location)  |
+| ⇧→     | ⇧-f   | C-a | Scroll right (at current cursor location) |
 
 #### Presentation
 
@@ -174,6 +188,24 @@ As before, you'll need to click the lock in the bottom left corner to unlock thi
 </p>
 
 If you encounter any problems, feel free to [file an issue][scoot-issues].
+
+### Activating vi Keybindings
+
+There is currently no UI for setting the keybinding mode.
+
+To opt in to vi keybindings, execute the following command in your terminal:
+
+```
+defaults write ~/Library/Preferences/com.mjrusso.Scoot.plist KeybindingMode vi
+```
+
+If Scoot is running, restart it after running the `defaults write` command.
+
+To restore the default keybindings:
+
+```
+defaults write ~/Library/Preferences/com.mjrusso.Scoot.plist KeybindingMode emacs
+```
 
 ## Demos
 

--- a/Scoot.xcodeproj/project.pbxproj
+++ b/Scoot.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		E511785B2636EEC800B4202F /* NSScreen+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511785A2636EEC800B4202F /* NSScreen+Extensions.swift */; };
 		E51178602636EEEB00B4202F /* NSPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E511785F2636EEEB00B4202F /* NSPoint+Extensions.swift */; };
 		E52BFD172763D5FB00BB65AF /* Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = E52BFD162763D5FB00BB65AF /* Accessibility.swift */; };
+		E53AB9D0279BA7ED0048FBE1 /* UserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53AB9CF279BA7ED0048FBE1 /* UserSettings.swift */; };
+		E53AB9D2279C416F0048FBE1 /* KeybindingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = E53AB9D1279C416F0048FBE1 /* KeybindingMode.swift */; };
 		E5497A03276E2C47006EA19B /* ElementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5497A02276E2C47006EA19B /* ElementView.swift */; };
 		E5497A05276E5E9D006EA19B /* CGPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5497A04276E5E9D006EA19B /* CGPoint+Extensions.swift */; };
 		E5497A07277D4F6A006EA19B /* CGRect+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5497A06277D4F6A006EA19B /* CGRect+Extensions.swift */; };
@@ -69,6 +71,8 @@
 		E511785A2636EEC800B4202F /* NSScreen+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSScreen+Extensions.swift"; sourceTree = "<group>"; };
 		E511785F2636EEEB00B4202F /* NSPoint+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSPoint+Extensions.swift"; sourceTree = "<group>"; };
 		E52BFD162763D5FB00BB65AF /* Accessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessibility.swift; sourceTree = "<group>"; };
+		E53AB9CF279BA7ED0048FBE1 /* UserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettings.swift; sourceTree = "<group>"; };
+		E53AB9D1279C416F0048FBE1 /* KeybindingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingMode.swift; sourceTree = "<group>"; };
 		E5497A02276E2C47006EA19B /* ElementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementView.swift; sourceTree = "<group>"; };
 		E5497A04276E5E9D006EA19B /* CGPoint+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPoint+Extensions.swift"; sourceTree = "<group>"; };
 		E5497A06277D4F6A006EA19B /* CGRect+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGRect+Extensions.swift"; sourceTree = "<group>"; };
@@ -180,6 +184,7 @@
 			children = (
 				E5776232262F04D300849D7D /* Main.storyboard */,
 				E577622C262F04D100849D7D /* AppDelegate.swift */,
+				E53AB9CF279BA7ED0048FBE1 /* UserSettings.swift */,
 				E52BFD162763D5FB00BB65AF /* Accessibility.swift */,
 				E59F854B278938F000A9FBF6 /* Positionable.swift */,
 				E59F854E27893B3A00A9FBF6 /* Positionable+Crowding.swift */,
@@ -190,6 +195,7 @@
 				E5B1DE4226686E9D00F1AA77 /* KeyboardInputWindow+Actions.swift */,
 				E567D2A3263C7FB000A0A861 /* KeyboardInputWindow+Keyboard.swift */,
 				E591E5662636F1F900C037FF /* KeyboardInputWindow+StandardKeyBinds.swift */,
+				E53AB9D1279C416F0048FBE1 /* KeybindingMode.swift */,
 				E5497A08277D5AD1006EA19B /* JumpMode.swift */,
 				E5BD595B26615F5300BB5181 /* JumpWindow.swift */,
 				E5776268262F0EC700849D7D /* JumpWindowController.swift */,
@@ -368,6 +374,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E53AB9D0279BA7ED0048FBE1 /* UserSettings.swift in Sources */,
 				E51178602636EEEB00B4202F /* NSPoint+Extensions.swift in Sources */,
 				E5497A03276E2C47006EA19B /* ElementView.swift in Sources */,
 				E52BFD172763D5FB00BB65AF /* Accessibility.swift in Sources */,
@@ -377,6 +384,7 @@
 				E567D2A2263C77FC00A0A861 /* Grid.swift in Sources */,
 				E5776261262F067700849D7D /* TransparentWindow.swift in Sources */,
 				E59F854C278938F100A9FBF6 /* Positionable.swift in Sources */,
+				E53AB9D2279C416F0048FBE1 /* KeybindingMode.swift in Sources */,
 				E59C1633264AC4F60033E2CC /* CGSize+Extensions.swift in Sources */,
 				E5776269262F0EC700849D7D /* JumpWindowController.swift in Sources */,
 				E577622F262F04D100849D7D /* JumpViewController.swift in Sources */,

--- a/Scoot/AppDelegate.swift
+++ b/Scoot/AppDelegate.swift
@@ -12,9 +12,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var hideMenuItem: NSMenuItem!
 
-    @IBOutlet weak var showElementsMenuItem: NSMenuItem!
+    @IBOutlet weak var useElementBasedNavigationMenuItem: NSMenuItem!
 
-    @IBOutlet weak var showGridMenuItem: NSMenuItem!
+    @IBOutlet weak var useGridBasedNavigationMenuItem: NSMenuItem!
+
+    @IBOutlet weak var useFreestyleNavigationMenuItem: NSMenuItem!
 
     lazy var inputWindow: KeyboardInputWindow = {
         NSApp.orderedWindows.compactMap({ $0 as? KeyboardInputWindow }).first!
@@ -30,18 +32,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         jumpWindowControllers.compactMap { $0.contentViewController as? JumpViewController }
     }
 
-    public var showElementsHotKey: HotKey? {
+    public var useElementBasedNavigationHotKey: HotKey? {
         didSet {
-            showElementsHotKey?.keyDownHandler = { [weak self] in
+            useElementBasedNavigationHotKey?.keyDownHandler = { [weak self] in
                 self?.bringToForeground(using: .element)
             }
         }
     }
 
-    public var showGridHotKey: HotKey? {
+    public var useGridBasedNavigationHotKey: HotKey? {
         didSet {
-            showGridHotKey?.keyDownHandler = { [weak self] in
+            useGridBasedNavigationHotKey?.keyDownHandler = { [weak self] in
                 self?.bringToForeground(using: .grid)
+            }
+        }
+    }
+
+    public var useFreestyleNavigationHotKey: HotKey? {
+        didSet {
+            useFreestyleNavigationHotKey?.keyDownHandler = { [weak self] in
+                self?.bringToForeground(using: .freestyle)
             }
         }
     }
@@ -87,9 +97,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        self.showElementsHotKey = HotKey(key: .j, modifiers: [.command, .shift])
+        self.useElementBasedNavigationHotKey = HotKey(key: .j, modifiers: [.command, .shift])
 
-        self.showGridHotKey = HotKey(key: .k, modifiers: [.command, .shift])
+        self.useGridBasedNavigationHotKey = HotKey(key: .k, modifiers: [.command, .shift])
+
+        self.useFreestyleNavigationHotKey = HotKey(key: .l, modifiers: [.command, .shift])
 
         self.configureMenuBarExtra()
 
@@ -251,12 +263,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         bringToBackground()
     }
 
-    @IBAction func showElementsPressed(_ sender: NSMenuItem) {
+    @IBAction func useElementBasedNavigationPressed(_ sender: NSMenuItem) {
         bringToForeground(using: .element)
     }
 
-    @IBAction func showGridPressed(_ sender: NSMenuItem) {
+    @IBAction func useGridBasedNavigationPressed(_ sender: NSMenuItem) {
         bringToForeground(using: .grid)
+    }
+
+    @IBAction func useFreestyleNavigationPressed(_ sender: NSMenuItem) {
+        bringToForeground(using: .freestyle)
     }
 
     @IBAction func helpPressed(_ sender: NSMenuItem) {

--- a/Scoot/AppDelegate.swift
+++ b/Scoot/AppDelegate.swift
@@ -112,6 +112,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             Logger().log("* Screen: \(screen.localizedName) \(String(describing: screen.frame))")
         }
 
+        Logger().log("Using \(UserSettings.shared.keybindingMode.rawValue) keybindings.")
+
         self.inputWindow.initializeCoreDataStructuresForGridBasedMovement()
 
         self.initializeChangeScreenParametersObserver()

--- a/Scoot/Base.lproj/Main.storyboard
+++ b/Scoot/Base.lproj/Main.storyboard
@@ -60,14 +60,19 @@
                                                 <action selector="hidePressed:" target="Voe-Tx-rLC" id="T4I-eg-084"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Show Elements" keyEquivalent="J" id="PJE-er-84e" userLabel="Show Elements">
+                                        <menuItem title="Use Element-Based Navigation" keyEquivalent="J" id="PJE-er-84e">
                                             <connections>
-                                                <action selector="showElementsPressed:" target="Voe-Tx-rLC" id="gLz-X4-6K0"/>
+                                                <action selector="useElementBasedNavigationPressed:" target="Voe-Tx-rLC" id="4Xw-km-gTr"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="Show Grid" keyEquivalent="K" id="9ey-1D-QEB">
+                                        <menuItem title="Use Grid-Based Navigation" keyEquivalent="K" id="9ey-1D-QEB">
                                             <connections>
-                                                <action selector="showGridPressed:" target="Voe-Tx-rLC" id="clY-p7-5wv"/>
+                                                <action selector="useGridBasedNavigationPressed:" target="Voe-Tx-rLC" id="myZ-45-CPZ"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Use Freestyle Navigation" keyEquivalent="L" id="GAo-D2-CNk">
+                                            <connections>
+                                                <action selector="useFreestyleNavigationPressed:" target="Voe-Tx-rLC" id="Lsy-R6-hic"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="Tu3-wV-t86"/>
@@ -147,8 +152,9 @@
                     <connections>
                         <outlet property="hideMenuItem" destination="Olw-nP-bQN" id="9Tb-8L-TjN"/>
                         <outlet property="menu" destination="Rkb-lU-63l" id="H8S-nT-JvV"/>
-                        <outlet property="showElementsMenuItem" destination="PJE-er-84e" id="kK9-md-IPf"/>
-                        <outlet property="showGridMenuItem" destination="9ey-1D-QEB" id="5I7-h7-147"/>
+                        <outlet property="useElementBasedNavigationMenuItem" destination="PJE-er-84e" id="kK9-md-IPf"/>
+                        <outlet property="useFreestyleNavigationMenuItem" destination="GAo-D2-CNk" id="BmX-7K-ulv"/>
+                        <outlet property="useGridBasedNavigationMenuItem" destination="9ey-1D-QEB" id="5I7-h7-147"/>
                     </connections>
                 </customObject>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>

--- a/Scoot/JumpMode.swift
+++ b/Scoot/JumpMode.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum JumpMode {
-    case grid
-    case element
+    case grid // Grid-based navigation mode.
+    case element // Element-based navigation mode.
+    case freestyle // A freeform usage mode, offering no navigation assistance.
 }

--- a/Scoot/KeybindingMode.swift
+++ b/Scoot/KeybindingMode.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+enum KeybindingMode: String {
+
+    // Emacs (and MacOS system) keybindings.
+    case emacs
+
+    // Vi-style keybindings.
+    case vi
+
+}
+
+extension KeybindingMode {
+
+    /// A list of special alphabetical characters (if any) that can conflict
+    /// with the characters used to build sequences in the character-based
+    /// decision tree.
+    var specialAlphas: [Character] {
+        switch self {
+        case .vi:
+            return ["j", "k", "h", "l"]
+        default:
+            return []
+        }
+    }
+
+    /// Returns true, if the character may conflict with the set of characters
+    /// available for building sequences in the character-based decision tree.
+    func isCharacterSpecial(_ character: Character) -> Bool {
+        self.specialAlphas.contains(character)
+    }
+
+}

--- a/Scoot/KeyboardInputWindow+Keyboard.swift
+++ b/Scoot/KeyboardInputWindow+Keyboard.swift
@@ -22,10 +22,10 @@ extension KeyboardInputWindow {
 
         // FIXME: this logic would be better encoded as a state machine.
 
-        if modifiers.isEmpty && characters.count == 1 && event.keyCode != kVK_Return {
+        if let tree = currentTree, modifiers.isEmpty && characters.count == 1 && event.keyCode != kVK_Return {
             let character = characters[characters.startIndex]
 
-            if let nextNode = (currentNode ?? currentTree.root).step(by: character) {
+            if let nextNode = (currentNode ?? tree.root).step(by: character) {
                 if nextNode.isLeaf , let rect = nextNode.value {
                     mouse.move(to: CGPoint(x: rect.midX, y: rect.midY))
                     flashFeedback(at: rect, duration: 1.4)

--- a/Scoot/KeyboardInputWindow+UI.swift
+++ b/Scoot/KeyboardInputWindow+UI.swift
@@ -11,10 +11,14 @@ extension KeyboardInputWindow {
             case .element:
                 $0.viewController.showElements()
                 $0.viewController.hideGrid()
+            case .freestyle:
+                $0.viewController.hideGrid()
+                $0.viewController.hideElements()
             }
         }
-        appDelegate?.showElementsMenuItem.isHidden = true
-        appDelegate?.showGridMenuItem.isHidden = true
+        appDelegate?.useElementBasedNavigationMenuItem.isHidden = true
+        appDelegate?.useGridBasedNavigationMenuItem.isHidden = true
+        appDelegate?.useFreestyleNavigationMenuItem.isHidden = true
         appDelegate?.hideMenuItem.isHidden = false
     }
 
@@ -23,8 +27,9 @@ extension KeyboardInputWindow {
             $0.viewController.hideGrid()
             $0.viewController.hideElements()
         }
-        appDelegate?.showElementsMenuItem.isHidden = false
-        appDelegate?.showGridMenuItem.isHidden = false
+        appDelegate?.useElementBasedNavigationMenuItem.isHidden = false
+        appDelegate?.useGridBasedNavigationMenuItem.isHidden = false
+        appDelegate?.useFreestyleNavigationMenuItem.isHidden = false
         appDelegate?.hideMenuItem.isHidden = true
     }
 

--- a/Scoot/KeyboardInputWindow.swift
+++ b/Scoot/KeyboardInputWindow.swift
@@ -33,12 +33,14 @@ class KeyboardInputWindow: TransparentWindow {
 
     /// The underlying data structure enabling cursor movement via a
     /// character-based decision tree (as determined by the active jump mode).
-    var currentTree: Tree<CGRect> {
+    var currentTree: Tree<CGRect>? {
         switch activeJumpMode {
         case .grid:
             return treeForGridBasedNavigation
         case .element:
             return treeForElementBasedNavigation
+        case .freestyle:
+            return nil
         }
     }
 

--- a/Scoot/KeyboardInputWindow.swift
+++ b/Scoot/KeyboardInputWindow.swift
@@ -221,16 +221,23 @@ class KeyboardInputWindow: TransparentWindow {
             ["z", "x", "c", "v", "b", "n", "m"],
         ]
 
+        let selectedKeys: [Character]
+
         switch numCandidates {
         case 0..<80:
-            return keys[0] + keys[1]
+            selectedKeys = keys[0] + keys[1]
         case 80..<200:
-            return keys[0] + keys[1] + keys[2]
+            selectedKeys = keys[0] + keys[1] + keys[2]
         case 200..<1400:
-            return keys[0] + keys[1] + keys[2] + keys[3]
+            selectedKeys = keys[0] + keys[1] + keys[2] + keys[3]
         default:
-            return keys.flatMap { $0 }
+            selectedKeys = keys.flatMap { $0 }
         }
+
+        return selectedKeys.filter {
+            !UserSettings.shared.keybindingMode.isCharacterSpecial($0)
+        }
+
     }
 
 }

--- a/Scoot/UserSettings.swift
+++ b/Scoot/UserSettings.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+class UserSettings {
+    static let shared = UserSettings()
+
+    @UserPersistedProperty("KeybindingMode", defaultValue: .emacs)
+    var keybindingMode: KeybindingMode
+}
+
+/// A property wrapper to simplify reading and writing from UserDefaults.
+///
+/// Adapted from: https://stackoverflow.com/a/63752463
+@propertyWrapper
+struct UserPersistedProperty<T: RawRepresentable> {
+
+    let key: String
+    let defaultValue: T
+
+    init(_ key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    var wrappedValue: T {
+        get {
+            guard let rawValue = UserDefaults.standard.object(forKey: key) as? T.RawValue, let value = T(rawValue: rawValue) else {
+                return defaultValue
+            }
+            return value
+        }
+        set {
+            UserDefaults.standard.set(newValue.rawValue, forKey: key)
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds support for navigation using vi bindings, and introduces a new usage mode (invoked with the ⇧⌘L global keyboard shortcut). For more context, see #12.

Thanks to @shadowgate15 for contributing (and adapting) the vi bindings.

Usage details are documented in the README, but a few notes for posterity —

The vi bindings need to be explicitly enabled. To turn them on:

```
defaults write ~/Library/Preferences/com.mjrusso.Scoot.plist KeybindingMode vi
```

(No UI for this, yet.)

Be sure to restart Scoot after toggling vi bindings on, or the app won't see the changes.

Freestyle mode is an alternative usage mode. When activated, it will bring Scoot to the foreground, but not activate any of the special "character based decision tree" machinery for moving around. However, all of the other keyboard shortcuts (the ones based on text editing shortcuts) will continue to work.