### PR TITLE
Fix keybinding for scrolling in vi mode

### DIFF
--- a/Scoot/KeyboardInputWindow+Keyboard.swift
+++ b/Scoot/KeyboardInputWindow+Keyboard.swift
@@ -109,23 +109,21 @@ extension KeyboardInputWindow {
             break
         }
 
-        if modifiers.contains(.shift) {
-            switch (mode, Int(event.keyCode), character) {
-            case (_, kVK_UpArrow, _), (.emacs, _, "P"), (.vi, _, "B"):
-                mouse.scroll(.up, stepSize: 20)
-                return
-            case (_, kVK_DownArrow, _), (.emacs, _, "N"), (.vi, _, "F"):
-                mouse.scroll(.down, stepSize: 20)
-                return
-            case (_, kVK_LeftArrow, _), (.emacs, _, "B"), (.vi, _, "I"):
-                mouse.scroll(.left, stepSize: 20)
-                return
-            case (_, kVK_RightArrow, _), (.emacs, _, "F"), (.vi, _, "A"):
-                mouse.scroll(.right, stepSize: 20)
-                return
-            default:
-                break
-            }
+        switch (mode, modifiers, Int(event.keyCode), character) {
+        case (_, .shift, kVK_UpArrow, _), (.emacs, .shift, _, "P"), (.vi, .control, _, "B"):
+            mouse.scroll(.up, stepSize: 20)
+            return
+        case (_, .shift, kVK_DownArrow, _), (.emacs, .shift, _, "N"), (.vi, .control, _, "F"):
+            mouse.scroll(.down, stepSize: 20)
+            return
+        case (_, .shift, kVK_LeftArrow, _), (.emacs, .shift, _, "B"), (.vi, .control, _, "I"):
+            mouse.scroll(.left, stepSize: 20)
+            return
+        case (_, .shift, kVK_RightArrow, _), (.emacs, .shift, _, "F"), (.vi, .control, _, "A"):
+            mouse.scroll(.right, stepSize: 20)
+            return
+        default:
+            break
         }
 
         // By default, we vend to the system directly (by calling `interpretKeyEvents`

--- a/Scoot/KeyboardInputWindow+Keyboard.swift
+++ b/Scoot/KeyboardInputWindow+Keyboard.swift
@@ -109,29 +109,28 @@ extension KeyboardInputWindow {
             break
         }
 
-        switch (mode, modifiers, Int(event.keyCode), character) {
-        case (_, .shift, kVK_UpArrow, _), (.emacs, .shift, _, "P"), (.vi, .control, _, "B"):
-            mouse.scroll(.up, stepSize: 20)
-            return
-        case (_, .shift, kVK_DownArrow, _), (.emacs, .shift, _, "N"), (.vi, .control, _, "F"):
-            mouse.scroll(.down, stepSize: 20)
-            return
-        case (_, .shift, kVK_LeftArrow, _), (.emacs, .shift, _, "B"), (.vi, .control, _, "I"):
-            mouse.scroll(.left, stepSize: 20)
-            return
-        case (_, .shift, kVK_RightArrow, _), (.emacs, .shift, _, "F"), (.vi, .control, _, "A"):
-            mouse.scroll(.right, stepSize: 20)
-            return
-        default:
-            break
-        }
-
         // By default, we vend to the system directly (by calling `interpretKeyEvents`
         // with the input event). However, in some cases we need to override the
         // system behaviour: for example, Control-A maps to `moveToBeginningOfParagraph`,
         // but `moveToBeginningOfLine` is more appropriate here.
 
         switch (mode, modifiers, character) {
+
+        case (.emacs, .shift, "P"), (.vi, .control, "b"),
+            (_, .shift, _) where Int(event.keyCode) == kVK_UpArrow:
+            mouse.scroll(.up, stepSize: 20)
+
+        case (.emacs, .shift, "N"), (.vi, .control, "f"),
+            (_, .shift, _) where Int(event.keyCode) == kVK_DownArrow:
+            mouse.scroll(.down, stepSize: 20)
+
+        case (.emacs, .shift, "B"), (.vi, .control, "i"),
+            (_, .shift, _) where Int(event.keyCode) == kVK_LeftArrow:
+            mouse.scroll(.left, stepSize: 20)
+
+        case (.emacs, .shift, "F"), (.vi, .control, "a"),
+            (_, .shift, _) where Int(event.keyCode) == kVK_RightArrow:
+            mouse.scroll(.right, stepSize: 20)
 
         case (.emacs, .control, "a"):
             // Emacs: move-beginning-of-line


### PR DESCRIPTION
The keybinding for scrolling in vi mode was mistakenly configured. For example, gotta scroll down with <kbd>Shift</kbd><kbd>F</kbd>. This PR aims to fix that by adding a check for `.control` modifier