### PR TITLE
Fix multi-monitor overlay stacking in Aerospace (Fixes #18)

### DIFF
--- a/Scoot/TransparentWindow.swift
+++ b/Scoot/TransparentWindow.swift
@@ -11,14 +11,26 @@ class TransparentWindow: NSWindow {
         isMovable = false
         ignoresMouseEvents = true
 
+        styleMask = .borderless
         collectionBehavior = [
-            // When the window becomes active, move it to the active space
-            // instead of switching spaces.
-            .moveToActiveSpace,
+            // The window exists on all Spaces simultaneously.
+            // This prevents the OS (or tiling window managers) from forcefully
+            // moving the window to the current display on activation.
+            .canJoinAllSpaces,
 
+            .fullScreenAuxiliary,
             // The window floats in Spaces and hides in Exposé.
             .transient,
         ]
+    }
+    
+    // Overrides tell Macos to handle keyboard events despite window being borderless
+    override var canBecomeKey: Bool {
+        return true
+    }
+
+    override var canBecomeMain: Bool {
+        return true
     }
 
 }


### PR DESCRIPTION
### Summary
Fixes #18. Addresses the issue where grid overlays for multiple monitors would all gather/stack onto the single active monitor when Scoot is activated on a system using Aerospace tiling window manager.

### Root Cause
The `TransparentWindow` base class includes `.moveToActiveSpace` in its collection behavior. This forces the OS to move all windows (including the grid overlays) to the active space immediately upon activation.

### The Fix
* Overrides `windowDidLoad` in `JumpWindowController` to explicitly remove `.moveToActiveSpace`.
* Adds `.canJoinAllSpaces` and `.borderless` styleMask.
* This ensures the grid windows remain anchored to their respective displays and are treated as floating auxiliary panels by the OS (and window managers like Aerospace/Yabai), this behavior was not reproducible in Amethyst WM as it just works.

### Testing
* Verified on macOS Tahoe 26.1
* Confirmed grid windows appear on correct monitors without stacking.
* Confirmed Input Window still works correctly (accepts keystrokes).