### PR TITLE
Fix #10 automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,144 @@
+name: Release Scoot
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers on tags like v1.2, v1.3.0
+
+permissions:
+  contents: write # Needed to upload the release
+
+jobs:
+  build-and-release:
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Validate MARKETING_VERSION matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          FILE="Scoot.xcodeproj/project.pbxproj"
+
+          echo "Tag version: $TAG_VERSION"
+
+          # Extract all MARKETING_VERSION values
+          VERSIONS=$(grep -E "MARKETING_VERSION = " "$FILE" \
+            | sed -E 's/.*MARKETING_VERSION = ([^;]+);/\1/' \
+            | sort -u)
+
+          echo "Found MARKETING_VERSION values:"
+          echo "$VERSIONS"
+
+          # Count unique versions
+          COUNT=$(echo "$VERSIONS" | wc -l | tr -d ' ')
+
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::Multiple different MARKETING_VERSION values found"
+            exit 1
+          fi
+
+          PROJECT_VERSION="$VERSIONS"
+
+          if [ "$PROJECT_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::MARKETING_VERSION ($PROJECT_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+          echo "All MARKETING_VERSION values match tag"
+
+      - name: Run Tests
+        run: |
+          xcodebuild test \
+            -scheme Scoot \
+            -destination 'platform=macOS' \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO
+
+      - name: Install Apple Certificate
+        env:
+          # Setup secrets 
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        run: |
+          # Configure keychain
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          
+          # Decode the certificate
+          echo "$BUILD_CERTIFICATE_BASE64" | base64 --decode > certificate.p12
+          
+          # Import certificate and allow codesign to access it
+          security import certificate.p12 -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+      - name: Create Export Options
+        # Generate config file needed for xcodebuild export
+        run: |
+          cat <<EOF > exportOptions.plist
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>developer-id</string>
+              <key>teamID</key>
+              <string>${{ secrets.AC_TEAM_ID }}</string>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Build and Archive
+        run: |
+          xcodebuild archive \
+            -scheme Scoot \
+            -archivePath "Scoot.xcarchive" \
+            -configuration Release \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_STYLE="Manual"
+
+      - name: Export .app
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "Scoot.xcarchive" \
+            -exportOptionsPlist exportOptions.plist \
+            -exportPath ./Output
+
+      - name: Zip for Notarization
+        run: |
+          cd Output
+          /usr/bin/ditto -c -k --keepParent "Scoot.app" "Scoot.zip"
+
+      - name: Notarize App
+        env:
+          AC_USERNAME: ${{ secrets.AC_USERNAME }} # Apple ID email
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }} # App-Specific Password
+          AC_TEAM_ID: ${{ secrets.AC_TEAM_ID }}   # Team ID 
+        run: |
+          # Submit to Apple
+          xcrun notarytool submit ./Output/Scoot.zip \
+            --apple-id "$AC_USERNAME" \
+            --password "$AC_PASSWORD" \
+            --team-id "$AC_TEAM_ID" \
+            --wait
+
+      - name: Staple and Re-Zip
+        run: |
+          # Staple the ticket to the .app (NOT the zip)
+          xcrun stapler staple "./Output/Scoot.app"
+          
+          # Re-create the zip with the stapled app inside
+          cd Output
+          rm Scoot.zip
+          /usr/bin/ditto -c -k --keepParent "Scoot.app" "Scoot.zip"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: Output/Scoot.zip


### PR DESCRIPTION
This is an attempt to automate the release process by way of tags. When a commit is tagged with a version number of the pattern `v*`, this workflow will kick off the following steps:
1 - Run Tests
2 - Install the apple certificate given the github secrets you setup. Instructions found here: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
3 - Build/Archive the app
4 - Export the app
5 - Notarize
6 - Staple
7 - Upload artifacts to Github Release