### PR TITLE
Enhance element label styling related to #4

### DIFF
--- a/Scoot/ElementView.swift
+++ b/Scoot/ElementView.swift
@@ -21,6 +21,7 @@ class ElementView: NSView {
         
         let shouldRoundBorders = UserSettings.shared.roundElementBorders
         let borderOpacity = UserSettings.shared.elementBorderOpacity
+        let backgroundOpacity = UserSettings.shared.elementBackgroundOpacity
         
         ctx.cgContext.setFillColor(
             NSColor.black.withAlphaComponent(
@@ -44,7 +45,7 @@ class ElementView: NSView {
 
         let backgroundColor = NSColor.black.withAlphaComponent(
             viewController.elementLabelBackgroundAlphaComponent
-        )
+        ).withAlphaComponent(backgroundOpacity)
         
         let borderColor = foregroundColor.withAlphaComponent(borderOpacity)
     

--- a/Scoot/SettingsView.swift
+++ b/Scoot/SettingsView.swift
@@ -38,6 +38,12 @@ struct SettingsView: View {
 
     @AppStorage(UserSettings.Constants.Names.elementViewFontSize)
     var elementViewFontSize = UserSettings.Constants.DefaultValues.elementViewFontSize
+    
+    @AppStorage(UserSettings.Constants.Names.roundElementBorders)
+    var roundElementBorders = UserSettings.Constants.DefaultValues.roundElementBorders
+    
+    @AppStorage(UserSettings.Constants.Names.elementBorderOpacity)
+    var elementBorderOpacity = UserSettings.Constants.DefaultValues.elementBorderOpacity
 
     // MARK: User Interface
 
@@ -62,7 +68,9 @@ struct SettingsView: View {
                 gridViewOverallContrast: $gridViewOverallContrast,
                 elementViewOverallContrast: $elementViewOverallContrast,
                 gridViewFontSize: $gridViewFontSize,
-                elementViewFontSize: $elementViewFontSize
+                elementViewFontSize: $elementViewFontSize,
+                roundElementBorders: $roundElementBorders,
+                elementBorderOpacity: $elementBorderOpacity
                 ).tabItem {
                     Label("Presentation", systemImage: "scribble.variable")
                 }
@@ -136,12 +144,15 @@ struct PresentationSettingsView: View {
     @Binding var elementViewOverallContrast: Double
     @Binding var gridViewFontSize: Double
     @Binding var elementViewFontSize: Double
+    @Binding var roundElementBorders: Bool
+    @Binding var elementBorderOpacity: Double
 
     let targetGridCellSideLengthConfig = UserSettings.Constants.Sliders.targetGridCellSideLength
     let gridViewOverallContrastConfig = UserSettings.Constants.Sliders.gridViewOverallContrast
     let elementViewOverallContrastConfig = UserSettings.Constants.Sliders.elementViewOverallContrast
     let gridViewFontSizeConfig = UserSettings.Constants.Sliders.gridViewFontSize
     let elementViewFontSizeConfig = UserSettings.Constants.Sliders.elementViewFontSize
+    let elementBorderOpacityConfig = UserSettings.Constants.Sliders.elementBorderOpacity
 
 
     var body: some View {
@@ -167,6 +178,11 @@ struct PresentationSettingsView: View {
                     .labelStyle(TitleOnlyLabelStyle())
                 Toggle("Show grid lines", isOn: $showGridLines)
                 Toggle("Show grid labels", isOn: $showGridLabels)
+                Toggle("Round element borders", isOn: $roundElementBorders)
+                Slider(value: $elementBorderOpacity, in: elementBorderOpacityConfig.range, step: elementBorderOpacityConfig.step){
+                    Label("Element border opacity", systemImage: "gear")
+                }
+                    .labelStyle(TitleOnlyLabelStyle())
                 Slider(value: $targetGridCellSideLength, in: targetGridCellSideLengthConfig.range, step: targetGridCellSideLengthConfig.step) {
                     Label("Grid Cell Size:", systemImage: "gear")
                 }
@@ -187,6 +203,14 @@ struct PresentationSettingsView: View {
         }
         .onChange(of: showGridLabels) { newValue in
             OSLog.main.log("Toggled showGridLabels to \(showGridLabels).")
+            (NSApp.delegate as? AppDelegate)?.inputWindow.redrawJumpViews()
+        }
+        .onChange(of: roundElementBorders) { newValue in
+            OSLog.main.log("Toggled roundElementBorders to \(roundElementBorders).")
+            (NSApp.delegate as? AppDelegate)?.inputWindow.redrawJumpViews()
+        }
+        .onChange(of: elementBorderOpacity){ newValue in
+            OSLog.main.log("Changed elementBorderOpacity to \(elementBorderOpacity).")
             (NSApp.delegate as? AppDelegate)?.inputWindow.redrawJumpViews()
         }
         .onChange(of: targetGridCellSideLength) { newValue in
@@ -233,6 +257,8 @@ struct PresentationSettingsView: View {
         elementViewOverallContrast = UserSettings.Constants.DefaultValues.elementViewOverallContrast
         gridViewFontSize = UserSettings.Constants.DefaultValues.gridViewFontSize
         elementViewFontSize = UserSettings.Constants.DefaultValues.elementViewFontSize
+        roundElementBorders = UserSettings.Constants.DefaultValues.roundElementBorders
+        elementBorderOpacity = UserSettings.Constants.DefaultValues.elementBorderOpacity
     }
 
 }
@@ -248,7 +274,9 @@ struct PresentationSettingsView_Previews: PreviewProvider {
             gridViewOverallContrast: .constant(0.0),
             elementViewOverallContrast: .constant(0.0),
             gridViewFontSize: .constant(18),
-            elementViewFontSize: .constant(14)
+            elementViewFontSize: .constant(14),
+            roundElementBorders: .constant(false),
+            elementBorderOpacity: .constant(0.7)
         )
     }
 }

--- a/Scoot/SettingsView.swift
+++ b/Scoot/SettingsView.swift
@@ -44,6 +44,9 @@ struct SettingsView: View {
     
     @AppStorage(UserSettings.Constants.Names.elementBorderOpacity)
     var elementBorderOpacity = UserSettings.Constants.DefaultValues.elementBorderOpacity
+    
+    @AppStorage(UserSettings.Constants.Names.elementBackgroundOpacity)
+    var elementBackgroundOpacity = UserSettings.Constants.DefaultValues.elementBackgroundOpacity
 
     // MARK: User Interface
 
@@ -70,7 +73,8 @@ struct SettingsView: View {
                 gridViewFontSize: $gridViewFontSize,
                 elementViewFontSize: $elementViewFontSize,
                 roundElementBorders: $roundElementBorders,
-                elementBorderOpacity: $elementBorderOpacity
+                elementBorderOpacity: $elementBorderOpacity,
+                elementBackgroundOpacity: $elementBackgroundOpacity
                 ).tabItem {
                     Label("Presentation", systemImage: "scribble.variable")
                 }
@@ -146,6 +150,7 @@ struct PresentationSettingsView: View {
     @Binding var elementViewFontSize: Double
     @Binding var roundElementBorders: Bool
     @Binding var elementBorderOpacity: Double
+    @Binding var elementBackgroundOpacity: Double
 
     let targetGridCellSideLengthConfig = UserSettings.Constants.Sliders.targetGridCellSideLength
     let gridViewOverallContrastConfig = UserSettings.Constants.Sliders.gridViewOverallContrast
@@ -153,6 +158,7 @@ struct PresentationSettingsView: View {
     let gridViewFontSizeConfig = UserSettings.Constants.Sliders.gridViewFontSize
     let elementViewFontSizeConfig = UserSettings.Constants.Sliders.elementViewFontSize
     let elementBorderOpacityConfig = UserSettings.Constants.Sliders.elementBorderOpacity
+    let elementBackgroundOpacityConfig = UserSettings.Constants.Sliders.elementBackgroundOpacity
 
 
     var body: some View {
@@ -183,6 +189,10 @@ struct PresentationSettingsView: View {
                     Label("Element border opacity", systemImage: "gear")
                 }
                     .labelStyle(TitleOnlyLabelStyle())
+                Slider(value: $elementBackgroundOpacity, in: elementBackgroundOpacityConfig.range, step: elementBackgroundOpacityConfig.step){
+                    Label("Element background opacity", systemImage: "gear")
+                }
+                .labelStyle(TitleOnlyLabelStyle())
                 Slider(value: $targetGridCellSideLength, in: targetGridCellSideLengthConfig.range, step: targetGridCellSideLengthConfig.step) {
                     Label("Grid Cell Size:", systemImage: "gear")
                 }
@@ -211,6 +221,10 @@ struct PresentationSettingsView: View {
         }
         .onChange(of: elementBorderOpacity){ newValue in
             OSLog.main.log("Changed elementBorderOpacity to \(elementBorderOpacity).")
+            (NSApp.delegate as? AppDelegate)?.inputWindow.redrawJumpViews()
+        }
+        .onChange(of: elementBackgroundOpacity){ newValue in
+            OSLog.main.log("Change elementBackgroundOpacity to \(elementBackgroundOpacity).")
             (NSApp.delegate as? AppDelegate)?.inputWindow.redrawJumpViews()
         }
         .onChange(of: targetGridCellSideLength) { newValue in
@@ -259,6 +273,7 @@ struct PresentationSettingsView: View {
         elementViewFontSize = UserSettings.Constants.DefaultValues.elementViewFontSize
         roundElementBorders = UserSettings.Constants.DefaultValues.roundElementBorders
         elementBorderOpacity = UserSettings.Constants.DefaultValues.elementBorderOpacity
+        elementBackgroundOpacity = UserSettings.Constants.DefaultValues.elementBackgroundOpacity
     }
 
 }
@@ -276,7 +291,8 @@ struct PresentationSettingsView_Previews: PreviewProvider {
             gridViewFontSize: .constant(18),
             elementViewFontSize: .constant(14),
             roundElementBorders: .constant(false),
-            elementBorderOpacity: .constant(0.7)
+            elementBorderOpacity: .constant(0.7),
+            elementBackgroundOpacity: .constant(1)
         )
     }
 }

--- a/Scoot/UserSettings.swift
+++ b/Scoot/UserSettings.swift
@@ -43,6 +43,7 @@ class UserSettings {
             static let elementViewFontSize = "ElementViewFontSize"
             static let roundElementBorders = "RoundElementBorders"
             static let elementBorderOpacity = "ElementBorderOpacity"
+            static let elementBackgroundOpacity = "ElementBackgroundOpacity"
         }
 
         struct DefaultValues {
@@ -58,6 +59,7 @@ class UserSettings {
             static let elementViewFontSize = Double(14)
             static let roundElementBorders = false
             static let elementBorderOpacity = Double(0.7)
+            static let elementBackgroundOpacity = Double(1)
         }
 
         struct Sliders {
@@ -78,6 +80,7 @@ class UserSettings {
             static let gridViewFontSize = Config(min: 10, max: 24, step: 2)
             static let elementViewFontSize = Config(min: 6, max: 22, step: 2)
             static let elementBorderOpacity = Config(min: 0.0, max: 1.0, step: 0.1)
+            static let elementBackgroundOpacity = Config(min: 0.0, max: 1.0, step: 0.1)
         }
 
     }
@@ -193,6 +196,15 @@ class UserSettings {
         }
         set {
             settingsView?.elementBorderOpacity = newValue
+        }
+    }
+    
+    var elementBackgroundOpacity: Double {
+        get {
+            settingsView?.elementBackgroundOpacity ?? Constants.DefaultValues.elementBackgroundOpacity
+        }
+        set {
+            settingsView?.elementBackgroundOpacity = newValue
         }
     }
 

--- a/Scoot/UserSettings.swift
+++ b/Scoot/UserSettings.swift
@@ -41,6 +41,8 @@ class UserSettings {
             static let elementViewOverallContrast = "ElementViewOverallContrast"
             static let gridViewFontSize = "GridViewFontSize"
             static let elementViewFontSize = "ElementViewFontSize"
+            static let roundElementBorders = "RoundElementBorders"
+            static let elementBorderOpacity = "ElementBorderOpacity"
         }
 
         struct DefaultValues {
@@ -54,6 +56,8 @@ class UserSettings {
             static let elementViewOverallContrast = Double(0)
             static let gridViewFontSize = Double(18)
             static let elementViewFontSize = Double(14)
+            static let roundElementBorders = false
+            static let elementBorderOpacity = Double(0.7)
         }
 
         struct Sliders {
@@ -73,6 +77,7 @@ class UserSettings {
             static let elementViewOverallContrast = Config(min: -0.4, max: 0.5, step: 0.1)
             static let gridViewFontSize = Config(min: 10, max: 24, step: 2)
             static let elementViewFontSize = Config(min: 6, max: 22, step: 2)
+            static let elementBorderOpacity = Config(min: 0.0, max: 1.0, step: 0.1)
         }
 
     }
@@ -127,6 +132,15 @@ class UserSettings {
             settingsView?.showGridLabels = newValue
         }
     }
+    
+    var roundElementBorders: Bool {
+        get {
+            settingsView?.roundElementBorders ?? Constants.DefaultValues.roundElementBorders
+        }
+        set {
+            settingsView?.roundElementBorders = newValue
+        }
+    }
 
     var targetGridCellSideLength: Double {
         get {
@@ -170,6 +184,15 @@ class UserSettings {
         }
         set {
             settingsView?.elementViewFontSize = newValue
+        }
+    }
+    
+    var elementBorderOpacity: Double {
+        get {
+            settingsView?.elementBorderOpacity ?? Constants.DefaultValues.elementBorderOpacity
+        }
+        set {
+            settingsView?.elementBorderOpacity = newValue
         }
     }
 


### PR DESCRIPTION
### Summary
Related to issue #4. Addresses concerns of element mode label contrast/legibility. 

### Root Cause
Element text not centered fully on the badge background because the standard text attributes do not support vertical alignment.

### Changes
* We first draw the black background then draw the text on top of that. This allows us to compute the central position for the text
* Two new user settings fields created
1) Round element borders
2) Element border opactity

<img width="418" height="51" alt="Screenshot 2025-12-22 at 10 36 02 PM" src="https://github.com/user-attachments/assets/a0e7b23d-ed22-40b3-a350-d66b48dcc878" />

---

The resulting change of the labels:
<img width="2513" height="1360" alt="Screenshot 2025-12-22 at 10 37 04 PM" src="https://github.com/user-attachments/assets/04a0d02c-634b-40a8-b89a-801d95bd9b92" />


### Testing
* Verified on macOS Tahoe 26.1
* Confirmed grid windows appear on correct monitors without stacking.
* Confirmed Input Window still works correctly (accepts keystrokes).