### PR TITLE
Fix #59 - scaled screen resolutions

### DIFF
--- a/Scoot/AppDelegate.swift
+++ b/Scoot/AppDelegate.swift
@@ -20,6 +20,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var useFreestyleNavigationMenuItem: NSMenuItem!
 
+    private var lastScreenValidationAlertAt: Date = .distantPast
+    private let screenValidationAlertCooldown: TimeInterval = 10
+
     lazy var inputWindow: KeyboardInputWindow = {
         NSApp.orderedWindows.compactMap({ $0 as? KeyboardInputWindow }).first!
     }()
@@ -217,6 +220,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.jumpWindowControllers.first(where: {
             $0.assignedScreen == screen
         })
+    }
+
+    func presentScreenValidationAlertIfNeeded(details: String? = nil) {
+        let now = Date()
+
+        guard now.timeIntervalSince(lastScreenValidationAlertAt) >= screenValidationAlertCooldown else {
+            return
+        }
+
+        lastScreenValidationAlertAt = now
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Screen configuration error"
+        alert.informativeText = """
+        Could not validate native/scaled screen size.
+        Scoot will retry automatically. If this persists, try restoring display scaling or reconnecting the monitor.
+        \(details.map { "\n\nDetails: \($0)" } ?? "")
+        """
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     // MARK: Settings UI

--- a/Scoot/CGRect+Validation.swift
+++ b/Scoot/CGRect+Validation.swift
@@ -1,0 +1,18 @@
+import CoreGraphics
+
+extension CGRect {
+    var hasFiniteComponents: Bool {
+        origin.x.isFinite &&
+        origin.y.isFinite &&
+        size.width.isFinite &&
+        size.height.isFinite
+    }
+
+    var isUsableScreenFrame: Bool {
+        hasFiniteComponents &&
+        !isNull &&
+        !isInfinite &&
+        width > 1 &&
+        height > 1
+    }
+}

--- a/Scoot/JumpWindowController.swift
+++ b/Scoot/JumpWindowController.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import OSLog
 
 class JumpWindowController: NSWindowController {
 
@@ -31,7 +32,16 @@ extension JumpWindowController {
 
     func assignScreen(screen: NSScreen) {
         self.assignedScreen = screen
-        setWindowFrame(screen.visibleFrame)
+
+        let frame = screen.visibleFrame
+
+        guard frame.isUsableScreenFrame else {
+            OSLog.main.error("Invalid screen frame detected: \(String(describing: frame), privacy: .public)")
+            appDelegate?.presentScreenValidationAlertIfNeeded(details: "\(frame)")
+            return
+        }
+
+        setWindowFrame(frame)
     }
 
     func setWindowFrame(_ frame: NSRect) {


### PR DESCRIPTION
Closes #59

## Summary

This PR hardens Scoot against crashes when toggling grid mode on scaled external displays (e.g. “Larger Text” modes), by validating screen geometry before grid/window operations and failing gracefully when geometry is transiently invalid.

## What changed

- Keep using AppKit point-space geometry (`NSScreen.visibleFrame`) as the layout source of truth.
- Add screen-frame validation before assigning jump-window frame.
- Add graceful failure path when frame validation fails:
  - log error/warning
  - show a user-facing warning popup:
    - **“Could not validate native/scaled screen size.”**
  - skip the invalid cycle instead of crashing.
- Add popup cooldown/rate-limiting to prevent alert spam during repeated display-change notifications.

## Implementation details

### `Scoot/JumpWindowController.swift`
- Validate `screen.visibleFrame` in `assignScreen(screen:)`.
- If invalid:
  - emit log
  - request app delegate alert (rate-limited)
  - return without applying invalid frame.

### `Scoot/AppDelegate.swift`
- Add `presentScreenValidationAlertIfNeeded(details:)` helper.
- Cooldown window (e.g. 10s) to avoid repeated alerts while display settings are transitioning.

### New helper
- `Scoot/CGRect+Validation.swift`
  - `hasFiniteComponents`
  - `isUsableScreenFrame` (`!isNull && !isInfinite && width > 1 && height > 1`)

## Why this fixes #59

Scaled display mode changes can briefly produce inconsistent geometry.  
This PR prevents invalid geometry from propagating into grid/window logic, avoiding abrupt exits and allowing automatic recovery on subsequent valid updates.

## Manual verification plan

- [ ] Start Scoot with external Retina monitor at default scaling; toggle grid mode repeatedly.
- [ ] Change monitor to **Larger Text**; toggle grid mode repeatedly.
- [ ] Change scaling while Scoot is running; verify no crash.
- [ ] Confirm warning popup appears only on invalid transitions and is rate-limited.
- [ ] Confirm normal behavior resumes once geometry stabilizes.